### PR TITLE
Renamed role and core and renamed guide

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -4,26 +4,26 @@ The apprentice stage is the first stage of learning a craft. All learners begin 
 # Chapter
 Chapters are the centers of learning identified by their geographic location (e.g. the Oakland Chapter). Chapters are the product- and service-delivery sites of learners guild. They are physical spaces designed for intensive, deliberate learning and growth. They receive material, financial, and logistical support from the core but are otherwise self-contained units.
 
-# Core
-The core is the central organizational body of Learners Guild. The core is responsible for all business and operational functions not explicitly under the domain of the chapters. The core is not explicitly geography-specific.
-
 # Craft
 Learners are involved with one or more crafts. These are the industries and skills which learners practice and work in. Software development is an example of a craft, as is graphic design, forestry, and photovoltaic technology.
 
 # Crew
 Learners are organized into crews. Crews are the atomic level of group organization in Learners Guild. Each crew has a defined purpose, domain, and objectives.
 
-# Guide
-Guides are learners who may or may not be actively working in a particular craft but have nonetheless achieved a high level of expertise in that craft. Their primary responsibility is to guide, mentor, and otherwise assist apprentices and practitioners in their learning.
+# Guild Core
+The Guilde Core is the central organizational body of Learners Guild. The Core is responsible for all business and operational functions not explicitly under the domain of the chapters. The core is not explicitly geography-specific.
 
 # Learner
 Everyone who works for or with Learners Guild is a learner. This includes the staff of the core as well as everyone involved with a guild chapter.
 
+# Mentor
+Mentors are learners who may or may not be actively working in a particular craft but have nonetheless achieved a high level of expertise in that craft. Their primary responsibility is to guide, mentor, and otherwise assist apprentices and practitioners in their learning.
+
 # Practitioner
 Practitioners are learners who are being paid to practice their craft. Their primary responsibilities are to their projects and to their own continued development and refinement of their craft. Practitioners who have reached a defined level of skill in their craft and have proven themselves to be good mentors can advance to become guides.
 
-# Role
-A craft is a profession which has a specific role associated with it. For example, the craft of software development is associated with the role "software developer". The craft of photovoltaic technology is associated with the role "solar electric technician".
+# Professional Role
+A craft is a profession which has a specific Professional Role associated with it. For example, the craft of software development is associated with the Role "software developer". The craft of photovoltaic technology is associated with the Role "solar electric technician".
 
 # Stages
 Within a role, learners move through three stages of development: apprentice, practitioner, and guide. For example, a learner might be an "apprentice software developer" or a "practicing solar electric technician" or a "mentor graphic designer". Learners can occupy multiple roles at once, and they can be at various stages in each role.


### PR DESCRIPTION
Prefaced role and core. Role could be confused with holacracy roles. 

Used mentor instead of guide.